### PR TITLE
增强 dev-tools 的 task mybatisGenerate 自动依赖

### DIFF
--- a/dev-tools/build.gradle
+++ b/dev-tools/build.gradle
@@ -33,9 +33,24 @@ def getDbProperties = {
 
 }
 
+task ensureIfDevToolsJarNotExist {
+    if (!file('../lib/dev-tools-1.0.jar').exists()) {
+        delete ('build/libs/dev-tools-1.0-SNAPSHOT.jar')
+    }
+}
 
-task mybatisGenerate << {
+jar.doLast {
+    copy {
+        from('build/libs') {
+            include 'dev-tools-1.0-SNAPSHOT.jar'
+        }
+        into '../lib'
+        rename 'dev-tools-1.0-SNAPSHOT.jar','dev-tools-1.0.jar'
+    }
+    println(':dev-tools jar was copied to /lib/dev-tools-1.0.jar')
+}
 
+task mybatisGenerate(dependsOn: [':dev-tools:ensureIfDevToolsJarNotExist',':dev-tools:jar']) << {
 
     def properties = getDbProperties()
 


### PR DESCRIPTION
现在会自动复制或更新 /lib/dev-tools-1.0.jar 的依赖了，只需要直接
执行 task mybatisGenerate

---

之前可能需要手动复制 /lib/dev-tools-1.0.jar ，现在引进新操作直接执行 task mybatisGenerate 时自动更新/复制。
